### PR TITLE
Add timeout option

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ If you use the httpClient just to set the timeout you can instead use WithTimeou
   client := clearbit.NewClient(clearbit.WithTimeout(20))
 ```
 
-Both can be combined and the order is not important.
+All options can be combined and the order is not important.
 
 Once the client is created you can use any of the Clearbit APIs
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,12 @@ You can tap another `http.Client` with:
   client := clearbit.NewClient(clearbit.WithHTTPClient(&http.Client{}))
 ```
 
+If you use the httpClient just to set the timeout you can instead use WithTimeout:
+
+```go
+  client := clearbit.NewClient(clearbit.WithTimeout(20))
+```
+
 Both can be combined and the order is not important.
 
 Once the client is created you can use any of the Clearbit APIs

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ You can tap another `http.Client` with:
 If you use the httpClient just to set the timeout you can instead use WithTimeout:
 
 ```go
-  client := clearbit.NewClient(clearbit.WithTimeout(20))
+  client := clearbit.NewClient(clearbit.WithTimeout(20 * time.Second))
 ```
 
 All options can be combined and the order is not important.

--- a/clearbit/clearbit.go
+++ b/clearbit/clearbit.go
@@ -19,22 +19,22 @@ type Client struct {
 	Reveal       *RevealService
 }
 
-// Config represents all the parameters available to configure a Clearbit
+// config represents all the parameters available to configure a Clearbit
 // client
-type Config struct {
+type config struct {
 	apiKey     string
 	httpClient *http.Client
-	Timeout    time.Duration
+	timeout    time.Duration
 }
 
 // Option is an option passed to the NewClient function used to change
 // the client configuration
-type Option func(*Config)
+type Option func(*config)
 
 // WithHTTPClient sets the optional http.Client we can use to make requests
 func WithHTTPClient(httpClient *http.Client) Option {
-	return func(config *Config) {
-		config.httpClient = httpClient
+	return func(c *config) {
+		c.httpClient = httpClient
 	}
 }
 
@@ -42,9 +42,9 @@ func WithHTTPClient(httpClient *http.Client) Option {
 //
 // When this is not provided we'll default to the `CLEARBIT_KEY` environment
 // variable.
-func WithAPIKey(apiKey string) func(*Config) {
-	return func(config *Config) {
-		config.apiKey = apiKey
+func WithAPIKey(apiKey string) func(*config) {
+	return func(c *config) {
+		c.apiKey = apiKey
 	}
 }
 
@@ -52,28 +52,28 @@ func WithAPIKey(apiKey string) func(*Config) {
 //
 // This is just an easier way to set the timeout than directly setting it
 // through the withHTTPClient option.
-func WithTimeout(d time.Duration) func(*Config) {
-	return func(config *Config) {
-		config.Timeout = d
+func WithTimeout(d time.Duration) func(*config) {
+	return func(c *config) {
+		c.timeout = d
 	}
 }
 
 // NewClient returns a new Client.
 func NewClient(options ...Option) *Client {
-	config := Config{
+	c := config{
 		apiKey:     os.Getenv("CLEARBIT_KEY"),
 		httpClient: &http.Client{},
-		Timeout:    10 * time.Second,
+		timeout:    10 * time.Second,
 	}
 
 	for _, option := range options {
-		option(&config)
+		option(&c)
 	}
 
-	config.httpClient.Timeout = config.Timeout
+	c.httpClient.Timeout = c.timeout
 
-	base := sling.New().Client(config.httpClient)
-	base.SetBasicAuth(config.apiKey, "")
+	base := sling.New().Client(c.httpClient)
+	base.SetBasicAuth(c.apiKey, "")
 
 	return &Client{
 		Autocomplete: newAutocompleteService(base.New()),

--- a/clearbit/clearbit.go
+++ b/clearbit/clearbit.go
@@ -22,9 +22,9 @@ type Client struct {
 // Config represents all the parameters available to configure a Clearbit
 // client
 type Config struct {
-	apiKey		string
-	httpClient 	*http.Client
-	secondsTimeout	int
+	apiKey         string
+	httpClient     *http.Client
+	secondsTimeout int
 }
 
 // Option is an option passed to the NewClient function used to change
@@ -61,8 +61,8 @@ func WithTimeout(s int) func(*Config) {
 // NewClient returns a new Client.
 func NewClient(options ...Option) *Client {
 	config := Config{
-		apiKey: os.Getenv("CLEARBIT_KEY"),
-		httpClient : &http.Client{},
+		apiKey:         os.Getenv("CLEARBIT_KEY"),
+		httpClient:     &http.Client{},
 		secondsTimeout: 10,
 	}
 

--- a/clearbit/clearbit.go
+++ b/clearbit/clearbit.go
@@ -22,9 +22,9 @@ type Client struct {
 // Config represents all the parameters available to configure a Clearbit
 // client
 type Config struct {
-	apiKey         string
-	httpClient     *http.Client
-	secondsTimeout int
+	apiKey     string
+	httpClient *http.Client
+	Timeout    time.Duration
 }
 
 // Option is an option passed to the NewClient function used to change
@@ -52,25 +52,25 @@ func WithAPIKey(apiKey string) func(*Config) {
 //
 // This is just an easier way to set the timeout than directly setting it
 // through the withHTTPClient option.
-func WithTimeout(s int) func(*Config) {
+func WithTimeout(s time.Duration) func(*Config) {
 	return func(config *Config) {
-		config.secondsTimeout = s
+		config.Timeout = s
 	}
 }
 
 // NewClient returns a new Client.
 func NewClient(options ...Option) *Client {
 	config := Config{
-		apiKey:         os.Getenv("CLEARBIT_KEY"),
-		httpClient:     &http.Client{},
-		secondsTimeout: 10,
+		apiKey:     os.Getenv("CLEARBIT_KEY"),
+		httpClient: &http.Client{},
+		Timeout:    10 * time.Second,
 	}
 
 	for _, option := range options {
 		option(&config)
 	}
 
-	config.httpClient.Timeout = time.Duration(config.secondsTimeout) * time.Second
+	config.httpClient.Timeout = config.Timeout
 
 	base := sling.New().Client(config.httpClient)
 	base.SetBasicAuth(config.apiKey, "")

--- a/clearbit/clearbit.go
+++ b/clearbit/clearbit.go
@@ -52,9 +52,9 @@ func WithAPIKey(apiKey string) func(*Config) {
 //
 // This is just an easier way to set the timeout than directly setting it
 // through the withHTTPClient option.
-func WithTimeout(s time.Duration) func(*Config) {
+func WithTimeout(d time.Duration) func(*Config) {
 	return func(config *Config) {
-		config.Timeout = s
+		config.Timeout = d
 	}
 }
 

--- a/clearbit/doc.go
+++ b/clearbit/doc.go
@@ -16,7 +16,7 @@ You can tap another http.Client with:
 
 If you use the httpClient just to set the timeout you can instead use WithTimeout:
 
-  client := clearbit.NewClient(clearbit.WithTimeout(20))
+  client := clearbit.NewClient(clearbit.WithTimeout(20 * time.Second))
 
 Both can be combined and the order is not important.
 

--- a/clearbit/doc.go
+++ b/clearbit/doc.go
@@ -14,6 +14,10 @@ You can tap another http.Client with:
 
   client := clearbit.NewClient(clearbit.WithHTTPClient(&http.Client{}))
 
+If you use the httpClient just to set the timeout you can instead use WithTimeout:
+
+  client := clearbit.NewClient(clearbit.WithTimeout(20))
+
 Both can be combined and the order is not important.
 
 Once the client is created you can use any of the Clearbit APIs

--- a/clearbit/examples_test.go
+++ b/clearbit/examples_test.go
@@ -18,6 +18,7 @@ func ExampleNewClient_manuallyConfiguringEverything_output() {
 	client := clearbit.NewClient(
 		clearbit.WithHTTPClient(&http.Client{}),
 		clearbit.WithAPIKey(yourApiKey),
+		clearbit.WithTimeout(20),
 	)
 
 	_, resp, _ := client.Discovery.Search(clearbit.DiscoverySearchParams{

--- a/clearbit/examples_test.go
+++ b/clearbit/examples_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"time"
 
 	"github.com/clearbit/clearbit-go/clearbit"
 )
@@ -18,7 +19,7 @@ func ExampleNewClient_manuallyConfiguringEverything_output() {
 	client := clearbit.NewClient(
 		clearbit.WithHTTPClient(&http.Client{}),
 		clearbit.WithAPIKey(yourApiKey),
-		clearbit.WithTimeout(20),
+		clearbit.WithTimeout(20*time.Second),
 	)
 
 	_, resp, _ := client.Discovery.Search(clearbit.DiscoverySearchParams{


### PR DESCRIPTION
This is just an option for the probably most common use case for httpClient which is setting the timeout. We can do
```go
clearbit.NewClient(clearbit.WithTimeout(20))
```

instead of
```go
clearbit.WithHTTPClient(&http.Client{ Timeout: 20 * time.Second })
```