### PR TITLE
add ability to query roles, seniorities, titles in prospector

### DIFF
--- a/clearbit/examples_test.go
+++ b/clearbit/examples_test.go
@@ -76,6 +76,22 @@ func ExampleProspectorService_Search_output() {
 	// Output: amit@clearbit.com 200 OK
 }
 
+func ExampleProspectorService_SearchWithRoles_output() {
+	client := clearbit.NewClient(clearbit.WithAPIKey(clearbitApiKey))
+	results, resp, err := client.Prospector.Search(clearbit.ProspectorSearchParams{
+		Domain: "clearbit.com",
+		Roles:  []string{"sales", "engineering"},
+	})
+
+	if err == nil {
+		fmt.Println(len(results), resp.Status)
+	} else {
+		handleError(err, resp)
+	}
+
+	// Output: 5 200 OK
+}
+
 func ExampleCompanyService_Find_output() {
 	client := clearbit.NewClient(clearbit.WithAPIKey(clearbitApiKey))
 	results, resp, err := client.Company.Find(clearbit.CompanyFindParams{

--- a/clearbit/examples_test.go
+++ b/clearbit/examples_test.go
@@ -9,13 +9,12 @@ import (
 	"github.com/clearbit/clearbit-go/clearbit"
 )
 
-var clearbitApiKey = os.Getenv("CLEARBIT_KEY")
-
 func handleError(err error, resp *http.Response) {
 	fmt.Printf("%#v\n%s\n", err, resp.Status)
 }
 
 func ExampleNewClient_manuallyConfiguringEverything_output() {
+	var clearbitApiKey = os.Getenv("CLEARBIT_KEY")
 	client := clearbit.NewClient(
 		clearbit.WithHTTPClient(&http.Client{}),
 		clearbit.WithAPIKey(clearbitApiKey),
@@ -32,7 +31,7 @@ func ExampleNewClient_manuallyConfiguringEverything_output() {
 }
 
 func ExampleRevealService_Find_output() {
-	client := clearbit.NewClient(clearbit.WithAPIKey(clearbitApiKey))
+	client := clearbit.NewClient()
 	results, resp, err := client.Reveal.Find(clearbit.RevealFindParams{
 		IP: "104.193.168.24",
 	})
@@ -47,7 +46,7 @@ func ExampleRevealService_Find_output() {
 }
 
 func ExampleAutocompleteService_Suggest_output() {
-	client := clearbit.NewClient(clearbit.WithAPIKey(clearbitApiKey))
+	client := clearbit.NewClient()
 	results, resp, err := client.Autocomplete.Suggest(clearbit.AutocompleteSuggestParams{
 		Query: "clearbit",
 	})
@@ -62,7 +61,7 @@ func ExampleAutocompleteService_Suggest_output() {
 }
 
 func ExampleProspectorService_Search_output() {
-	client := clearbit.NewClient(clearbit.WithAPIKey(clearbitApiKey))
+	client := clearbit.NewClient()
 	results, resp, err := client.Prospector.Search(clearbit.ProspectorSearchParams{
 		Domain: "clearbit.com",
 	})
@@ -77,7 +76,7 @@ func ExampleProspectorService_Search_output() {
 }
 
 func ExampleProspectorService_SearchWithRoles_output() {
-	client := clearbit.NewClient(clearbit.WithAPIKey(clearbitApiKey))
+	client := clearbit.NewClient()
 	results, resp, err := client.Prospector.Search(clearbit.ProspectorSearchParams{
 		Domain: "clearbit.com",
 		Roles:  []string{"sales", "engineering"},
@@ -93,7 +92,7 @@ func ExampleProspectorService_SearchWithRoles_output() {
 }
 
 func ExampleCompanyService_Find_output() {
-	client := clearbit.NewClient(clearbit.WithAPIKey(clearbitApiKey))
+	client := clearbit.NewClient()
 	results, resp, err := client.Company.Find(clearbit.CompanyFindParams{
 		Domain: "clearbit.com",
 	})
@@ -108,7 +107,7 @@ func ExampleCompanyService_Find_output() {
 }
 
 func ExamplePersonService_Find_output() {
-	client := clearbit.NewClient(clearbit.WithAPIKey(clearbitApiKey))
+	client := clearbit.NewClient()
 	results, resp, err := client.Person.Find(clearbit.PersonFindParams{
 		Email: "alex@clearbit.com",
 	})
@@ -123,7 +122,7 @@ func ExamplePersonService_Find_output() {
 }
 
 func ExamplePersonService_FindCombined_output() {
-	client := clearbit.NewClient(clearbit.WithAPIKey(clearbitApiKey))
+	client := clearbit.NewClient()
 	results, resp, err := client.Person.FindCombined(clearbit.PersonFindParams{
 		Email: "alex@clearbit.com",
 	})
@@ -138,7 +137,7 @@ func ExamplePersonService_FindCombined_output() {
 }
 
 func ExampleDiscoveryService_Search_output() {
-	client := clearbit.NewClient(clearbit.WithAPIKey(clearbitApiKey))
+	client := clearbit.NewClient()
 	results, resp, err := client.Discovery.Search(clearbit.DiscoverySearchParams{
 		Query: "name:clearbit",
 	})

--- a/clearbit/examples_test.go
+++ b/clearbit/examples_test.go
@@ -9,16 +9,16 @@ import (
 	"github.com/clearbit/clearbit-go/clearbit"
 )
 
+var clearbitApiKey = os.Getenv("CLEARBIT_KEY")
+
 func handleError(err error, resp *http.Response) {
 	fmt.Printf("%#v\n%s\n", err, resp.Status)
 }
 
 func ExampleNewClient_manuallyConfiguringEverything_output() {
-	yourApiKey := os.Getenv("CLEARBIT_KEY")
-
 	client := clearbit.NewClient(
 		clearbit.WithHTTPClient(&http.Client{}),
-		clearbit.WithAPIKey(yourApiKey),
+		clearbit.WithAPIKey(clearbitApiKey),
 		clearbit.WithTimeout(20*time.Second),
 	)
 
@@ -32,7 +32,7 @@ func ExampleNewClient_manuallyConfiguringEverything_output() {
 }
 
 func ExampleRevealService_Find_output() {
-	client := clearbit.NewClient()
+	client := clearbit.NewClient(clearbit.WithAPIKey(clearbitApiKey))
 	results, resp, err := client.Reveal.Find(clearbit.RevealFindParams{
 		IP: "104.193.168.24",
 	})
@@ -47,7 +47,7 @@ func ExampleRevealService_Find_output() {
 }
 
 func ExampleAutocompleteService_Suggest_output() {
-	client := clearbit.NewClient()
+	client := clearbit.NewClient(clearbit.WithAPIKey(clearbitApiKey))
 	results, resp, err := client.Autocomplete.Suggest(clearbit.AutocompleteSuggestParams{
 		Query: "clearbit",
 	})
@@ -62,7 +62,7 @@ func ExampleAutocompleteService_Suggest_output() {
 }
 
 func ExampleProspectorService_Search_output() {
-	client := clearbit.NewClient()
+	client := clearbit.NewClient(clearbit.WithAPIKey(clearbitApiKey))
 	results, resp, err := client.Prospector.Search(clearbit.ProspectorSearchParams{
 		Domain: "clearbit.com",
 	})
@@ -73,11 +73,11 @@ func ExampleProspectorService_Search_output() {
 		handleError(err, resp)
 	}
 
-	// Output: chris@clearbit.com 200 OK
+	// Output: amit@clearbit.com 200 OK
 }
 
 func ExampleCompanyService_Find_output() {
-	client := clearbit.NewClient()
+	client := clearbit.NewClient(clearbit.WithAPIKey(clearbitApiKey))
 	results, resp, err := client.Company.Find(clearbit.CompanyFindParams{
 		Domain: "clearbit.com",
 	})
@@ -92,7 +92,7 @@ func ExampleCompanyService_Find_output() {
 }
 
 func ExamplePersonService_Find_output() {
-	client := clearbit.NewClient()
+	client := clearbit.NewClient(clearbit.WithAPIKey(clearbitApiKey))
 	results, resp, err := client.Person.Find(clearbit.PersonFindParams{
 		Email: "alex@clearbit.com",
 	})
@@ -107,7 +107,7 @@ func ExamplePersonService_Find_output() {
 }
 
 func ExamplePersonService_FindCombined_output() {
-	client := clearbit.NewClient()
+	client := clearbit.NewClient(clearbit.WithAPIKey(clearbitApiKey))
 	results, resp, err := client.Person.FindCombined(clearbit.PersonFindParams{
 		Email: "alex@clearbit.com",
 	})
@@ -122,7 +122,7 @@ func ExamplePersonService_FindCombined_output() {
 }
 
 func ExampleDiscoveryService_Search_output() {
-	client := clearbit.NewClient()
+	client := clearbit.NewClient(clearbit.WithAPIKey(clearbitApiKey))
 	results, resp, err := client.Discovery.Search(clearbit.DiscoverySearchParams{
 		Query: "name:clearbit",
 	})

--- a/clearbit/prospector.go
+++ b/clearbit/prospector.go
@@ -27,11 +27,11 @@ type ProspectorItem struct {
 type ProspectorSearchParams struct {
 	Domain      string   `url:"domain,omitempty"`
 	Role        string   `url:"role,omitempty"`
-	Roles       []string `url:"roles,omitempty"`
+	Roles       []string `url:"roles[],omitempty"`
 	Seniority   string   `url:"seniority,omitempty"`
-	Seniorities []string `url:"seniorities,omitempty"`
+	Seniorities []string `url:"seniorities[],omitempty"`
 	Title       string   `url:"title,omitempty"`
-	Titles      []string `url:"titles,omitempty"`
+	Titles      []string `url:"titles[],omitempty"`
 	Name        string   `url:"name,omitempty"`
 	Limit       int      `url:"limit,omitempty"`
 }

--- a/clearbit/prospector.go
+++ b/clearbit/prospector.go
@@ -1,8 +1,9 @@
 package clearbit
 
 import (
-	"github.com/dghubble/sling"
 	"net/http"
+
+	"github.com/dghubble/sling"
 )
 
 const (
@@ -24,12 +25,15 @@ type ProspectorItem struct {
 // ProspectorSearchParams wraps the parameters needed to interact with the
 // Prospector API
 type ProspectorSearchParams struct {
-	Domain    string `url:"domain,omitempty"`
-	Role      string `url:"role,omitempty"`
-	Seniority string `url:"seniority,omitempty"`
-	Title     string `url:"title,omitempty"`
-	Name      string `url:"name,omitempty"`
-	Limit     int    `url:"limit,omitempty"`
+	Domain      string   `url:"domain,omitempty"`
+	Role        string   `url:"role,omitempty"`
+	Roles       []string `url:"roles,omitempty"`
+	Seniority   string   `url:"seniority,omitempty"`
+	Seniorities []string `url:"seniorities,omitempty"`
+	Title       string   `url:"title,omitempty"`
+	Titles      []string `url:"titles,omitempty"`
+	Name        string   `url:"name,omitempty"`
+	Limit       int      `url:"limit,omitempty"`
 }
 
 // ProspectorService gives access to the Prospector API.


### PR DESCRIPTION
The latest version of the Prospector API allows users to query multiple `roles`, `titles`, and `seniorities`.

This update allows a user of this package to specify them 👍 