### PR TITLE
Update prospector client to use pagination

### DIFF
--- a/clearbit/examples_test.go
+++ b/clearbit/examples_test.go
@@ -99,7 +99,7 @@ func ExampleProspectorService_Search_output() {
 	})
 
 	if err == nil {
-		fmt.Println(results[0].Email, resp.Status)
+		fmt.Println(results.Results[0].Email, resp.Status)
 	} else {
 		handleError(err, resp)
 	}
@@ -115,7 +115,7 @@ func ExampleProspectorService_Search_withRoles_Output() {
 	})
 
 	if err == nil {
-		fmt.Println(len(results), resp.Status)
+		fmt.Println(len(results.Results), resp.Status)
 	} else {
 		handleError(err, resp)
 	}

--- a/clearbit/prospector.go
+++ b/clearbit/prospector.go
@@ -30,6 +30,8 @@ type ProspectorResponse struct {
 		} `json:"company"`
 		Email    string `json:"email"`
 		Location string `json:"location"`
+		Phone    string `json:"phone"`
+		Verified bool   `json:"verified"`
 	} `json:"results"`
 }
 

--- a/clearbit/prospector.go
+++ b/clearbit/prospector.go
@@ -8,7 +8,7 @@ import (
 
 const (
 	prospectorBase = "https://prospector.clearbit.com"
-	apiVersion     = "2016-10-04"
+	apiVersion     = "2018-08-15"
 )
 
 type ProspectorResponse struct {
@@ -45,10 +45,15 @@ type ProspectorSearchParams struct {
 	Seniorities []string `url:"seniorities[],omitempty"`
 	Title       string   `url:"title,omitempty"`
 	Titles      []string `url:"titles[],omitempty"`
+	City        string   `url:"city,omitempty"`
+	Cities      []string `url:"cities[],omitempty"`
+	State       string   `url:"state,omitempty"`
+	States      []string `url:"states[],omitempty"`
+	Country     string   `url:"country,omitempty"`
+	Countries   []string `url:"countries[],omitempty"`
 	Name        string   `url:"name,omitempty"`
 	Page        int      `url:"page,omitempty"`
 	PageSize    int      `url:"page_size,omitempty"`
-	Location    int      `url:"location,omitempty"`
 }
 
 // ProspectorService gives access to the Prospector API.

--- a/clearbit/prospector.go
+++ b/clearbit/prospector.go
@@ -46,8 +46,8 @@ type ProspectorSearchParams struct {
 	Title       string   `url:"title,omitempty"`
 	Titles      []string `url:"titles[],omitempty"`
 	Name        string   `url:"name,omitempty"`
-	Limit       int      `url:"limit,omitempty"`
 	Page        int      `url:"page,omitempty"`
+	PageSize    int      `url:"page_size,omitempty"`
 	Location    int      `url:"location,omitempty"`
 }
 

--- a/clearbit/prospector.go
+++ b/clearbit/prospector.go
@@ -11,16 +11,26 @@ const (
 	apiVersion     = "2016-10-04"
 )
 
-// ProspectorItem represents each of the items returned by a call to Search
-type ProspectorItem struct {
-	ID   string `json:"id"`
-	Name struct {
-		FullName   string `json:"fullName"`
-		GivenName  string `json:"givenName"`
-		FamilyName string `json:"familyName"`
-	} `json:"name"`
-	Title string `json:"title"`
-	Email string `json:"email"`
+type ProspectorResponse struct {
+	Page     int `json:"page"`
+	PageSize int `json:"page_size"`
+	Total    int `json:"total"`
+	Results  []struct {
+		ID   string `json:"id"`
+		Name struct {
+			FullName   string `json:"fullName"`
+			GivenName  string `json:"givenName"`
+			FamilyName string `json:"familyName"`
+		} `json:"name"`
+		Title     string `json:"title"`
+		Role      string `json:"role"`
+		Seniority string `json:"seniority"`
+		Company   struct {
+			Name string `json:"name"`
+		} `json:"company"`
+		Email    string `json:"email"`
+		Location string `json:"location"`
+	} `json:"results"`
 }
 
 // ProspectorSearchParams wraps the parameters needed to interact with the
@@ -35,6 +45,8 @@ type ProspectorSearchParams struct {
 	Titles      []string `url:"titles[],omitempty"`
 	Name        string   `url:"name,omitempty"`
 	Limit       int      `url:"limit,omitempty"`
+	Page        int      `url:"page,omitempty"`
+	Location    int      `url:"location,omitempty"`
 }
 
 // ProspectorService gives access to the Prospector API.
@@ -55,9 +67,9 @@ func newProspectorService(sling *sling.Sling) *ProspectorService {
 
 // Search lets you fetch contacts and emails associated with a company,
 // employment role, seniority, and job title.
-func (s *ProspectorService) Search(params ProspectorSearchParams) ([]ProspectorItem, *http.Response, error) {
-	items := new([]ProspectorItem)
+func (s *ProspectorService) Search(params ProspectorSearchParams) (ProspectorResponse, *http.Response, error) {
+	pr := new(ProspectorResponse)
 	ae := new(apiError)
-	resp, err := s.sling.New().Get("search").QueryStruct(params).Receive(items, ae)
-	return *items, resp, relevantError(err, *ae)
+	resp, err := s.sling.New().Get("search").QueryStruct(params).Receive(pr, ae)
+	return *pr, resp, relevantError(err, *ae)
 }


### PR DESCRIPTION
We've upgraded the prospector API to support pagination. This commit
adds the new response structure and input params.